### PR TITLE
Fixes #8959 - DataExporter: Styles error on xls, xlsx and xlsxtream when using custom locale

### DIFF
--- a/primefaces/src/main/java/org/primefaces/component/datatable/export/DataTableExcelExporter.java
+++ b/primefaces/src/main/java/org/primefaces/component/datatable/export/DataTableExcelExporter.java
@@ -448,7 +448,7 @@ public class DataTableExcelExporter extends DataTableExporter {
             currencyStyle = wb.createCellStyle();
             currencyStyle.setFont(font);
             currencyStyle.setAlignment(HorizontalAlignment.RIGHT);
-            String pattern = CurrencyValidator.getInstance().getPattern(locale);
+            String pattern = CurrencyValidator.getInstance().getExcelPattern(locale);
             short currencyPattern = wb.getCreationHelper().createDataFormat().getFormat(pattern);
             currencyStyle.setDataFormat(currencyPattern);
             applyCellOptions(wb, options, currencyStyle);

--- a/primefaces/src/main/java/org/primefaces/component/treetable/export/TreeTableExcelExporter.java
+++ b/primefaces/src/main/java/org/primefaces/component/treetable/export/TreeTableExcelExporter.java
@@ -449,7 +449,7 @@ public class TreeTableExcelExporter extends TreeTableExporter {
             currencyStyle = wb.createCellStyle();
             currencyStyle.setFont(font);
             currencyStyle.setAlignment(HorizontalAlignment.RIGHT);
-            String pattern = CurrencyValidator.getInstance().getPattern(locale);
+            String pattern = CurrencyValidator.getInstance().getExcelPattern(locale);
             short currencyPattern = wb.getCreationHelper().createDataFormat().getFormat(pattern);
             currencyStyle.setDataFormat(currencyPattern);
             applyCellOptions(wb, options, currencyStyle);

--- a/primefaces/src/main/java/org/primefaces/util/CurrencyValidator.java
+++ b/primefaces/src/main/java/org/primefaces/util/CurrencyValidator.java
@@ -218,16 +218,16 @@ public class CurrencyValidator implements Serializable {
 
     /**
      * <p>
-     * Returns a <code>String</code> representing the pattern for this currency.
+     * Returns a <code>String</code> representing the Excel pattern for this currency.
      * </p>
      *
      * @param locale The locale a <code>NumberFormat</code> is required for, system default if null.
-     * @return The <code>String</code> pattern.
+     * @return The <code>String</code> pattern for using in Excel format.
      */
-    public String getPattern(Locale locale) {
+    public String getExcelPattern(Locale locale) {
         DecimalFormat format = getFormat(locale);
         String pattern = format.toLocalizedPattern();
-        pattern =  pattern.replace(CURRENCY_SYMBOL_STR, format.getDecimalFormatSymbols().getCurrencySymbol());
+        pattern =  pattern.replace(CURRENCY_SYMBOL_STR, "\"" + format.getDecimalFormatSymbols().getCurrencySymbol() + "\"");
         String[] patterns = pattern.split(";");
         return patterns[0];
     }

--- a/primefaces/src/test/java/org/primefaces/util/CurrencyValidatorTest.java
+++ b/primefaces/src/test/java/org/primefaces/util/CurrencyValidatorTest.java
@@ -137,6 +137,7 @@ public class CurrencyValidatorTest {
 
         assertEquals("\"" + usDollar + "\"" + "#,##0.00", validator.getExcelPattern(Locale.US), "US");
         assertEquals("\"" + ukPound + "\"" +  "#,##0.00", validator.getExcelPattern(Locale.UK), "UK");
+        assertEquals("\"US$\"#,##0.00", validator.getExcelPattern(new Locale("es", "US")), "Custom");
     }
 
     /**

--- a/primefaces/src/test/java/org/primefaces/util/CurrencyValidatorTest.java
+++ b/primefaces/src/test/java/org/primefaces/util/CurrencyValidatorTest.java
@@ -41,16 +41,16 @@ public class CurrencyValidatorTest {
     private static String usDollar;
     private static String ukPound;
     private static String brazilReal;
+    private static String customCurrencySymbol;
     private static Locale brazil = new Locale("pt", "BR");
-    public static final Locale customLocale = new Locale("es", "US");
-    public static String customLocaleCurrencySymbol;
+    private static Locale custom = new Locale("es", "US");
 
     @BeforeAll
     protected static void setUp() throws Exception {
         usDollar = (new DecimalFormatSymbols(Locale.US)).getCurrencySymbol();
         ukPound = (new DecimalFormatSymbols(Locale.UK)).getCurrencySymbol();
         brazilReal = (new DecimalFormatSymbols(brazil)).getCurrencySymbol();
-        customLocaleCurrencySymbol = (new DecimalFormatSymbols(customLocale)).getCurrencySymbol();
+        customCurrencySymbol = (new DecimalFormatSymbols(custom)).getCurrencySymbol();
     }
 
     private static int getVersion() {
@@ -140,7 +140,7 @@ public class CurrencyValidatorTest {
 
         assertEquals("\"" + usDollar + "\"" + "#,##0.00", validator.getExcelPattern(Locale.US), "US");
         assertEquals("\"" + ukPound + "\"" +  "#,##0.00", validator.getExcelPattern(Locale.UK), "UK");
-        assertEquals("\"" + customLocaleCurrencySymbol + "\"#,##0.00", validator.getExcelPattern(customLocale), "Custom");
+        assertEquals("\"" + customCurrencySymbol + "\"#,##0.00", validator.getExcelPattern(custom), "Custom");
     }
 
     /**

--- a/primefaces/src/test/java/org/primefaces/util/CurrencyValidatorTest.java
+++ b/primefaces/src/test/java/org/primefaces/util/CurrencyValidatorTest.java
@@ -42,12 +42,15 @@ public class CurrencyValidatorTest {
     private static String ukPound;
     private static String brazilReal;
     private static Locale brazil = new Locale("pt", "BR");
+    public static final Locale customLocale = new Locale("es", "US");
+    public static String customLocaleCurrencySymbol;
 
     @BeforeAll
     protected static void setUp() throws Exception {
         usDollar = (new DecimalFormatSymbols(Locale.US)).getCurrencySymbol();
         ukPound = (new DecimalFormatSymbols(Locale.UK)).getCurrencySymbol();
         brazilReal = (new DecimalFormatSymbols(brazil)).getCurrencySymbol();
+        customLocaleCurrencySymbol = (new DecimalFormatSymbols(customLocale)).getCurrencySymbol();
     }
 
     private static int getVersion() {
@@ -137,7 +140,7 @@ public class CurrencyValidatorTest {
 
         assertEquals("\"" + usDollar + "\"" + "#,##0.00", validator.getExcelPattern(Locale.US), "US");
         assertEquals("\"" + ukPound + "\"" +  "#,##0.00", validator.getExcelPattern(Locale.UK), "UK");
-        assertEquals("\"US$\"#,##0.00", validator.getExcelPattern(new Locale("es", "US")), "Custom");
+        assertEquals("\"" + customLocaleCurrencySymbol + "\"#,##0.00", validator.getExcelPattern(customLocale), "Custom");
     }
 
     /**

--- a/primefaces/src/test/java/org/primefaces/util/CurrencyValidatorTest.java
+++ b/primefaces/src/test/java/org/primefaces/util/CurrencyValidatorTest.java
@@ -132,11 +132,11 @@ public class CurrencyValidatorTest {
      * Test Patterns
      */
     @Test
-    public void testPatterns() {
+    public void testExcelPatterns() {
         CurrencyValidator validator = CurrencyValidator.getInstance();
 
-        assertEquals(usDollar + "#,##0.00", validator.getPattern(Locale.US), "US");
-        assertEquals(ukPound + "#,##0.00", validator.getPattern(Locale.UK), "UK");
+        assertEquals("\"" + usDollar + "\"" + "#,##0.00", validator.getExcelPattern(Locale.US), "US");
+        assertEquals("\"" + ukPound + "\"" +  "#,##0.00", validator.getExcelPattern(Locale.UK), "UK");
     }
 
     /**


### PR DESCRIPTION
Fixes #8959 by escaping the currency symbols